### PR TITLE
Refactor README.md to use ESM import syntax and update for Payload 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ pnpm add payload-db
 
 ```javascript
 // Import necessary packages
-const { DB, configureDatabase } = require('payload-db');
-const payload = require('payload');
-const express = require('express');
+import { DB, configureDatabase } from 'payload-db';
+import payload from 'payload';
+import express from 'express';
 
 // Define your schema with simplified syntax
 const dbConfig = DB({

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ pnpm add payload-db
 ```javascript
 // Import necessary packages
 import { DB, configureDatabase } from 'payload-db';
-import payload from 'payload';
-import express from 'express';
+import { buildConfig } from 'payload/config';
 
 // Define your schema with simplified syntax
 const dbConfig = DB({
@@ -62,19 +61,12 @@ dbConfig.config.db = configureDatabase({
   uri: process.env.MONGODB_URI || 'mongodb://localhost:27017/my-database'
 });
 
-// Initialize express app
-const app = express();
-
 // Initialize Payload with the generated configuration
-payload.init({
-  secret: process.env.PAYLOAD_SECRET || 'your-secret-key',
-  express: app,
-  config: dbConfig.config
-}).then(() => {
-  // Start express server
-  app.listen(3000, () => {
-    console.log('Server started on port 3000');
-  });
+// For Payload 3.0 with NextJS, you would typically use this in your payload.config.ts file
+export default buildConfig({
+  // Your other Payload config options
+  collections: dbConfig.config.collections,
+  db: dbConfig.config.db,
 });
 ```
 


### PR DESCRIPTION
This PR updates the README.md to use modern ESM import syntax instead of CommonJS require statements and updates the example to be compatible with Payload 3.0 which uses NextJS instead of Express.

Changes made:
- Changed `const { DB, configureDatabase } = require("payload-db")` to `import { DB, configureDatabase } from "payload-db"`
- Changed `const payload = require("payload")` to `import { buildConfig } from "payload/config"`
- Removed Express references and updated the example to use Payload 3.0 with NextJS
- Updated the initialization code to use buildConfig instead of the Express-based initialization

These changes align the documentation with modern JavaScript practices and the latest version of Payload CMS.

Fixes #3

@nathanclevenger can click here to [continue refining the PR](https://app.all-hands.dev/conversations/81dd10f1ab944449ae5c18f02d823708)