### PR TITLE
Rename payload-db to simple-payload

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Payload CMS Architecture
 
-This document provides an overview of Payload CMS's architecture, focusing on collections and fields. Payload-db aims to provide a simplified interface for defining Payload CMS data models while maintaining compatibility with Payload's powerful features.
+This document provides an overview of Payload CMS's architecture, focusing on collections and fields. Simple-payload aims to provide a simplified interface for defining Payload CMS data models while maintaining compatibility with Payload's powerful features.
 
 ## Collections
 
@@ -114,11 +114,11 @@ Most fields in Payload share these common configuration options:
 | `localized` | Enable localization for this field |
 | `admin` | Admin-specific configuration |
 
-## Payload-db Simplified Syntax
+## Simple-payload Simplified Syntax
 
-Payload-db provides a simplified syntax for defining Payload CMS data models. It abstracts away much of the complexity while maintaining compatibility with Payload's powerful features.
+Simple-payload provides a simplified syntax for defining Payload CMS data models. It abstracts away much of the complexity while maintaining compatibility with Payload's powerful features.
 
-Example of standard Payload syntax vs. payload-db simplified syntax:
+Example of standard Payload syntax vs. simple-payload simplified syntax:
 
 ### Standard Payload Syntax
 
@@ -150,7 +150,7 @@ const Posts = {
 }
 ```
 
-### Payload-db Simplified Syntax
+### Simple-payload Simplified Syntax
 
 ```javascript
 const db = DB({
@@ -172,7 +172,7 @@ const db = DB({
 })
 ```
 
-The payload-db syntax provides a more concise way to define collections and their relationships, while still leveraging the full power of Payload CMS under the hood.
+The simple-payload syntax provides a more concise way to define collections and their relationships, while still leveraging the full power of Payload CMS under the hood.
 
 ## Key Features
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# payload-db
+# simple-payload
 
 Simplified Data Schema Definition for [Payload CMS](https://payloadcms.com) applications using concise syntax.
 
 ## Overview
 
-`payload-db` is a lightweight schema generator for Payload CMS that enables extremely concise data model definitions. This package focuses purely on transforming a simplified schema format into Payload CMS compatible configuration, making it easier to define your data models with minimal code.
+`simple-payload` is a lightweight schema generator for Payload CMS that enables extremely concise data model definitions. This package focuses purely on transforming a simplified schema format into Payload CMS compatible configuration, making it easier to define your data models with minimal code.
 
 ## Features
 
@@ -19,18 +19,18 @@ Simplified Data Schema Definition for [Payload CMS](https://payloadcms.com) appl
 ## Installation
 
 ```bash
-npm install payload-db
+npm install simple-payload
 # or
-yarn add payload-db
+yarn add simple-payload
 # or
-pnpm add payload-db
+pnpm add simple-payload
 ```
 
 ## Quick Start
 
 ```javascript
 // Import necessary packages
-import { DB, configureDatabase } from 'payload-db';
+import { DB, configureDatabase } from 'simple-payload';
 import { buildConfig } from 'payload/config';
 
 // Define your schema with simplified syntax

--- a/examples/basic-example/README.md
+++ b/examples/basic-example/README.md
@@ -1,6 +1,6 @@
-# payload-db Basic Example
+# simple-payload Basic Example
 
-This example demonstrates how to use the `payload-db` package to create a simple blog application with posts, authors, and tags using a simplified schema definition.
+This example demonstrates how to use the `simple-payload` package to create a simple blog application with posts, authors, and tags using a simplified schema definition.
 
 ## Prerequisites
 
@@ -13,11 +13,11 @@ This example demonstrates how to use the `payload-db` package to create a simple
 1. **Clone the repository**
 
 ```bash
-git clone https://github.com/yourusername/payload-db.git
-cd payload-db
+git clone https://github.com/yourusername/simple-payload.git
+cd simple-payload
 ```
 
-2. **Build the payload-db package**
+2. **Build the simple-payload package**
 
 ```bash
 npm install
@@ -35,7 +35,7 @@ touch .env
 Add the following content (adjust as needed for your environment):
 
 ```
-MONGODB_URI=mongodb://localhost:27017/payload-db-example
+MONGODB_URI=mongodb://localhost:27017/simple-payload-example
 PAYLOAD_SECRET=your-secret-key-change-me
 ```
 
@@ -66,7 +66,7 @@ The example demonstrates several key concepts:
 
 This example demonstrates:
 
-1. **Simplified Schema Definition** - See how easy it is to define your data model using the payload-db concise syntax
+1. **Simplified Schema Definition** - See how easy it is to define your data model using the simple-payload concise syntax
 2. **Select Fields with Options** - Define select fields with predefined options using the pipe syntax
 3. **Join Fields** - Define reverse relationships between collections with the `<-` syntax
 4. **Schema Transformation** - See how our simplified schema gets transformed into Payload CMS configuration

--- a/examples/basic-example/index.js
+++ b/examples/basic-example/index.js
@@ -1,9 +1,9 @@
 /**
- * Basic example of how to use payload-db
+ * Basic example of how to use simple-payload
  */
 
 // In a real application, you would import from the package
-// const { DB, configureDatabase } = require('payload-db');
+// const { DB, configureDatabase } = require('simple-payload');
 // For this example, we'll import from the local package
 const { DB, configureDatabase } = require('../../dist');
 
@@ -50,7 +50,7 @@ const dbConfig = DB({
 // Configure the database connection
 dbConfig.config.db = configureDatabase({
   type: 'mongodb',
-  uri: process.env.MONGODB_URI || 'mongodb://localhost:27017/payload-db-example'
+  uri: process.env.MONGODB_URI || 'mongodb://localhost:27017/simple-payload-example'
 });
 
 // Initialize express app
@@ -104,8 +104,8 @@ async function main() {
     const post = await payloadInstance.create({
       collection: 'posts',
       data: {
-        title: 'Getting Started with payload-db',
-        content: '<p>This is a sample post created using payload-db.</p>',
+        title: 'Getting Started with simple-payload',
+        content: '<p>This is a sample post created using simple-payload.</p>',
         slug: 'getting-started',
         status: 'Published', // Using select option - make sure it matches one of the defined options
         contentType: 'Markdown', // Using select option

--- a/examples/basic-example/package.json
+++ b/examples/basic-example/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "payload-db-example",
+  "name": "simple-payload-example",
   "version": "1.0.0",
-  "description": "Example application demonstrating payload-db usage",
+  "description": "Example application demonstrating simple-payload usage",
   "main": "index.js",
   "scripts": {
     "start": "node index.js"
@@ -11,7 +11,7 @@
     "express": "^4.17.1",
     "payload": "^2.0.0",
     "@payloadcms/db-mongodb": "^1.0.0",
-    "payload-db": "file:../.."
+    "simple-payload": "file:../.."
   },
   "engines": {
     "node": ">=16.0.0"

--- a/examples/crm-example/README.md
+++ b/examples/crm-example/README.md
@@ -1,6 +1,6 @@
-# Payload DB CRM Example
+# Simple Payload CRM Example
 
-This example demonstrates how to build a comprehensive Customer Relationship Management (CRM) system using Payload DB. It showcases how to model complex business relationships and data structures common in CRM applications, focusing on payload-db as an agnostic data modeling and access layer.
+This example demonstrates how to build a comprehensive Customer Relationship Management (CRM) system using Simple Payload. It showcases how to model complex business relationships and data structures common in CRM applications, focusing on simple-payload as an agnostic data modeling and access layer.
 
 ## Features
 

--- a/examples/crm-example/index.js
+++ b/examples/crm-example/index.js
@@ -1,9 +1,9 @@
 /**
- * CRM example using payload-db
+ * CRM example using simple-payload
  */
 
 // In a real application, you would import from the package
-// const { DB, configureDatabase } = require('payload-db')
+// const { DB, configureDatabase } = require('simple-payload')
 // For this example, we'll import from the local package
 const { DB, configureDatabase } = require('../../dist')
 
@@ -145,14 +145,14 @@ const db = DB({
 // Option 1: MongoDB
 db.config.db = configureDatabase({
   type: 'mongodb',
-  uri: process.env.MONGODB_URI || 'mongodb://localhost:27017/payload-db-crm-example'
+  uri: process.env.MONGODB_URI || 'mongodb://localhost:27017/simple-payload-crm-example'
 })
 
 // Option 2: PostgreSQL (commented out)
 /*
 db.config.db = configureDatabase({
   type: 'postgres',
-  uri: process.env.POSTGRES_URI || 'postgresql://user:password@localhost:5432/payload-db-crm-example'
+  uri: process.env.POSTGRES_URI || 'postgresql://user:password@localhost:5432/simple-payload-crm-example'
 })
 */
 
@@ -160,7 +160,7 @@ db.config.db = configureDatabase({
 /*
 db.config.db = configureDatabase({
   type: 'sqlite',
-  uri: process.env.SQLITE_PATH || './payload-db-crm-example.sqlite'
+  uri: process.env.SQLITE_PATH || './simple-payload-crm-example.sqlite'
 })
 */
 

--- a/examples/crm-example/package.json
+++ b/examples/crm-example/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "payload-db-crm-example",
+  "name": "simple-payload-crm-example",
   "version": "1.0.0",
-  "description": "A CRM example using payload-db",
+  "description": "A CRM example using simple-payload",
   "main": "index.js",
   "scripts": {
     "start": "node index.js"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "payload-db",
+  "name": "simple-payload",
   "version": "0.1.0",
   "description": "Simplified Data Schema Definition for Payload CMS applications using concise syntax",
   "main": "dist/index.js",
@@ -46,10 +46,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nathanclevenger/payload-db.git"
+    "url": "git+https://github.com/ai-primitives/simple-payload.git"
   },
   "bugs": {
-    "url": "https://github.com/nathanclevenger/payload-db/issues"
+    "url": "https://github.com/ai-primitives/simple-payload/issues"
   },
-  "homepage": "https://github.com/nathanclevenger/payload-db#readme"
+  "homepage": "https://github.com/ai-primitives/simple-payload#readme"
 }


### PR DESCRIPTION
Fixes #7 - Updating all references from payload-db to simple-payload in the codebase.

Link to Devin run: https://app.devin.ai/sessions/4b4b8782ae7941e6a178aa2fe9dfcce3
Requested by: user