### PR TITLE
Update test suite with comprehensive coverage

### DIFF
--- a/src/__tests__/comprehensive-collections.test.ts
+++ b/src/__tests__/comprehensive-collections.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from 'vitest';
+import { DB } from '../index';
+
+describe('Comprehensive Collection Tests', () => {
+  describe('Multiple Collections with Various Relationships', () => {
+    it('should handle a complex schema with multiple collections and relationship types', () => {
+      const schema = {
+        posts: {
+          title: 'text',
+          content: 'richtext',
+          status: 'Draft | Published | Archived',
+          author: 'users',
+          categories: 'categories[]',
+          tags: 'tags[]',
+          relatedPosts: 'posts[]'
+        },
+        users: {
+          name: 'text',
+          email: 'email',
+          role: 'Admin | Editor | Author | Viewer',
+          bio: 'richtext',
+          authoredPosts: '<-posts.author',
+          favoriteCategories: 'categories[]'
+        },
+        categories: {
+          name: 'text',
+          description: 'textarea',
+          parent: 'categories',
+          posts: '<-posts.categories',
+          subcategories: '<-categories.parent'
+        },
+        tags: {
+          name: 'text',
+          posts: '<-posts.tags'
+        },
+        comments: {
+          content: 'richtext',
+          author: 'users',
+          post: 'posts',
+          parent: 'comments',
+          replies: '<-comments.parent'
+        },
+        media: {
+          title: 'text',
+          file: 'text', // Simplified for testing
+          alt: 'text',
+          posts: '<-posts.media'
+        }
+      };
+      
+      const result = DB(schema);
+      
+      // Verify all collections exist
+      expect(result.collections).toHaveLength(6);
+      
+      // Verify collection slugs
+      const collectionSlugs = result.collections.map((c: any) => c.slug);
+      expect(collectionSlugs).toContain('posts');
+      expect(collectionSlugs).toContain('users');
+      expect(collectionSlugs).toContain('categories');
+      expect(collectionSlugs).toContain('tags');
+      expect(collectionSlugs).toContain('comments');
+      expect(collectionSlugs).toContain('media');
+      
+      // Verify collection references
+      expect(result.collectionRefs).toHaveProperty('posts');
+      expect(result.collectionRefs).toHaveProperty('users');
+      expect(result.collectionRefs).toHaveProperty('categories');
+      expect(result.collectionRefs).toHaveProperty('tags');
+      expect(result.collectionRefs).toHaveProperty('comments');
+      expect(result.collectionRefs).toHaveProperty('media');
+      
+      // Check self-referential relationships
+      const postsCollection = result.collections.find((c: any) => c.slug === 'posts');
+      const relatedPostsField = postsCollection?.fields.find((f: any) => f.name === 'relatedPosts') as any;
+      expect(relatedPostsField?.type).toBe('relationship');
+      expect(relatedPostsField?.relationTo).toBe('posts');
+      expect(relatedPostsField?.hasMany).toBe(true);
+      
+      const categoriesCollection = result.collections.find((c: any) => c.slug === 'categories');
+      const parentCategoryField = categoriesCollection?.fields.find((f: any) => f.name === 'parent') as any;
+      expect(parentCategoryField?.type).toBe('relationship');
+      expect(parentCategoryField?.relationTo).toBe('categories');
+      expect(parentCategoryField?.hasMany).toBeUndefined();
+      
+      const commentsCollection = result.collections.find((c: any) => c.slug === 'comments');
+      const parentCommentField = commentsCollection?.fields.find((f: any) => f.name === 'parent') as any;
+      expect(parentCommentField?.type).toBe('relationship');
+      expect(parentCommentField?.relationTo).toBe('comments');
+      expect(parentCommentField?.hasMany).toBeUndefined();
+    });
+  });
+
+  describe('Circular References', () => {
+    it('should handle circular references between collections', () => {
+      const schema = {
+        products: {
+          name: 'text',
+          category: 'categories',
+          relatedProducts: 'products[]'
+        },
+        categories: {
+          name: 'text',
+          parentCategory: 'categories',
+          products: '<-products.category'
+        },
+        orders: {
+          orderNumber: 'text',
+          customer: 'customers',
+          products: 'products[]'
+        },
+        customers: {
+          name: 'text',
+          email: 'email',
+          orders: '<-orders.customer',
+          favoriteProducts: 'products[]'
+        }
+      };
+      
+      const result = DB(schema);
+      
+      // Verify all collections exist
+      expect(result.collections).toHaveLength(4);
+      
+      // Check circular references
+      const productsCollection = result.collections.find((c: any) => c.slug === 'products');
+      const relatedProductsField = productsCollection?.fields.find((f: any) => f.name === 'relatedProducts') as any;
+      expect(relatedProductsField?.type).toBe('relationship');
+      expect(relatedProductsField?.relationTo).toBe('products');
+      expect(relatedProductsField?.hasMany).toBe(true);
+      
+      const categoriesCollection = result.collections.find((c: any) => c.slug === 'categories');
+      const parentCategoryField = categoriesCollection?.fields.find((f: any) => f.name === 'parentCategory') as any;
+      expect(parentCategoryField?.type).toBe('relationship');
+      expect(parentCategoryField?.relationTo).toBe('categories');
+      expect(parentCategoryField?.hasMany).toBeUndefined();
+      
+      // Check cross-collection relationships
+      const categoryField = productsCollection?.fields.find((f: any) => f.name === 'category') as any;
+      expect(categoryField?.type).toBe('relationship');
+      expect(categoryField?.relationTo).toBe('categories');
+      
+      const ordersCollection = result.collections.find((c: any) => c.slug === 'orders');
+      const customerField = ordersCollection?.fields.find((f: any) => f.name === 'customer') as any;
+      expect(customerField?.type).toBe('relationship');
+      expect(customerField?.relationTo).toBe('customers');
+      
+      const productsField = ordersCollection?.fields.find((f: any) => f.name === 'products') as any;
+      expect(productsField?.type).toBe('relationship');
+      expect(productsField?.relationTo).toBe('products');
+      expect(productsField?.hasMany).toBe(true);
+      
+      const customersCollection = result.collections.find((c: any) => c.slug === 'customers');
+      const favoriteProductsField = customersCollection?.fields.find((f: any) => f.name === 'favoriteProducts') as any;
+      expect(favoriteProductsField?.type).toBe('relationship');
+      expect(favoriteProductsField?.relationTo).toBe('products');
+      expect(favoriteProductsField?.hasMany).toBe(true);
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle collections with no fields', () => {
+      const schema = {
+        emptyCollection: {}
+      };
+      
+      const result = DB(schema);
+      
+      // Verify the collection exists
+      expect(result.collections).toHaveLength(1);
+      const collection = result.collections[0];
+      expect(collection.slug).toBe('emptyCollection');
+      expect(collection.fields).toHaveLength(0);
+    });
+    
+    it('should handle collections with only join fields', () => {
+      const schema = {
+        posts: {
+          title: 'text',
+          author: 'users'
+        },
+        users: {
+          name: 'text'
+        },
+        joinOnly: {
+          userPosts: '<-posts.author'
+        }
+      };
+      
+      const result = DB(schema);
+      
+      // Verify all collections exist
+      expect(result.collections).toHaveLength(3);
+      
+      // Find the joinOnly collection
+      const joinOnlyCollection = result.collections.find((c: any) => c.slug === 'joinOnly');
+      expect(joinOnlyCollection).toBeDefined();
+      
+      // The join field should be removed from the collection
+      expect(joinOnlyCollection?.fields).toHaveLength(0);
+      
+      // But the collection should still exist
+      expect(result.collectionRefs).toHaveProperty('joinOnly');
+    });
+    
+    it('should handle collections with only relationship fields', () => {
+      const schema = {
+        users: {
+          name: 'text'
+        },
+        relOnly: {
+          user: 'users',
+          users: 'users[]'
+        }
+      };
+      
+      const result = DB(schema);
+      
+      // Verify all collections exist
+      expect(result.collections).toHaveLength(2);
+      
+      // Find the relOnly collection
+      const relOnlyCollection = result.collections.find((c: any) => c.slug === 'relOnly');
+      expect(relOnlyCollection).toBeDefined();
+      
+      // Check the relationship fields
+      expect(relOnlyCollection?.fields).toHaveLength(2);
+      
+      const userField = relOnlyCollection?.fields.find((f: any) => f.name === 'user') as any;
+      expect(userField?.type).toBe('relationship');
+      expect(userField?.relationTo).toBe('users');
+      expect(userField?.hasMany).toBeUndefined();
+      
+      const usersField = relOnlyCollection?.fields.find((f: any) => f.name === 'users') as any;
+      expect(usersField?.type).toBe('relationship');
+      expect(usersField?.relationTo).toBe('users');
+      expect(usersField?.hasMany).toBe(true);
+    });
+  });
+});

--- a/src/__tests__/comprehensive-edge-cases.test.ts
+++ b/src/__tests__/comprehensive-edge-cases.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect } from 'vitest';
+import { DB } from '../index';
+
+describe('Comprehensive Edge Cases', () => {
+  describe('Complex Nested Relationships', () => {
+    it('should handle deeply nested relationships correctly', () => {
+      const schema = {
+        organizations: {
+          name: 'text',
+          departments: '<-departments.organization'
+        },
+        departments: {
+          name: 'text',
+          organization: 'organizations',
+          teams: '<-teams.department'
+        },
+        teams: {
+          name: 'text',
+          department: 'departments',
+          projects: '<-projects.team'
+        },
+        projects: {
+          name: 'text',
+          team: 'teams',
+          tasks: '<-tasks.project'
+        },
+        tasks: {
+          name: 'text',
+          project: 'projects',
+          assignee: 'users',
+          subtasks: '<-tasks.parentTask'
+        },
+        users: {
+          name: 'text',
+          assignedTasks: '<-tasks.assignee',
+          team: 'teams'
+        }
+      };
+      
+      const result = DB(schema);
+      
+      // Verify all collections exist
+      expect(result.collections).toHaveLength(6);
+      
+      // Check that all collections are properly processed
+      const collectionSlugs = result.collections.map((c: any) => c.slug);
+      expect(collectionSlugs).toContain('organizations');
+      expect(collectionSlugs).toContain('departments');
+      expect(collectionSlugs).toContain('teams');
+      expect(collectionSlugs).toContain('projects');
+      expect(collectionSlugs).toContain('tasks');
+      expect(collectionSlugs).toContain('users');
+      
+      // Check that join fields are properly removed
+      const organizationsCollection = result.collections.find((c: any) => c.slug === 'organizations');
+      const departmentsJoinField = organizationsCollection?.fields.find((f: any) => f.name === 'departments');
+      expect(departmentsJoinField).toBeUndefined();
+      
+      // Check that relationship fields are properly set up
+      const departmentsCollection = result.collections.find((c: any) => c.slug === 'departments');
+      const organizationField = departmentsCollection?.fields.find((f: any) => f.name === 'organization') as any;
+      expect(organizationField).toBeDefined();
+      expect(organizationField?.type).toBe('relationship');
+      expect(organizationField?.relationTo).toBe('organizations');
+      
+      // Check that self-referential relationships work
+      const tasksCollection = result.collections.find((c: any) => c.slug === 'tasks');
+      const subtasksField = tasksCollection?.fields.find((f: any) => f.name === 'subtasks');
+      // This should be undefined because it's a join field that gets removed
+      expect(subtasksField).toBeUndefined();
+      
+      // But the parentTask field should exist
+      const parentTaskField = tasksCollection?.fields.find((f: any) => f.name === 'parentTask');
+      // This might be undefined if the schema doesn't define it, which is fine for this test
+      // The important thing is that the subtasks join field is removed
+    });
+  });
+
+  describe('Field Name Edge Cases', () => {
+    it('should handle field names with special characters and reserved words', () => {
+      const schema = {
+        edgeCases: {
+          'field-with-dashes': 'text',
+          'field_with_underscores': 'text',
+          'field.with.dots': 'text',
+          'field with spaces': 'text',
+          '123numericStart': 'text',
+          '$specialChar': 'text',
+          'type': 'text',        // Reserved word in JS
+          'constructor': 'text', // Reserved word in JS
+          'prototype': 'text',   // Reserved word in JS
+          'toString': 'text',    // Reserved word in JS
+          '__proto__': 'text'    // Reserved word in JS
+        }
+      };
+      
+      const result = DB(schema);
+      
+      // Verify the collection exists
+      expect(result.collections).toHaveLength(1);
+      const collection = result.collections[0];
+      expect(collection.slug).toBe('edgeCases');
+      
+      // Check that all fields are processed
+      expect(collection.fields).toHaveLength(10);
+      
+      // Check specific fields
+      const fieldWithDashes = collection.fields.find((f: any) => f.name === 'field-with-dashes');
+      expect(fieldWithDashes).toBeDefined();
+      expect(fieldWithDashes?.type).toBe('text');
+      
+      const fieldWithUnderscores = collection.fields.find((f: any) => f.name === 'field_with_underscores');
+      expect(fieldWithUnderscores).toBeDefined();
+      expect(fieldWithUnderscores?.type).toBe('text');
+      
+      const typeField = collection.fields.find((f: any) => f.name === 'type');
+      expect(typeField).toBeDefined();
+      expect(typeField?.type).toBe('text');
+    });
+  });
+
+  describe('Collection Name Edge Cases', () => {
+    it('should handle collection names with special characters and reserved words', () => {
+      const schema = {
+        'collection-with-dashes': {
+          field: 'text'
+        },
+        'collection_with_underscores': {
+          field: 'text'
+        },
+        'collection.with.dots': {
+          field: 'text'
+        },
+        'collection with spaces': {
+          field: 'text'
+        },
+        '123numericStart': {
+          field: 'text'
+        },
+        '$specialChar': {
+          field: 'text'
+        },
+        'type': {
+          field: 'text'
+        },
+        'constructor': {
+          field: 'text'
+        }
+      };
+      
+      const result = DB(schema);
+      
+      // Verify all collections exist
+      expect(result.collections).toHaveLength(8);
+      
+      // Check specific collections
+      const collectionWithDashes = result.collections.find((c: any) => c.slug === 'collection-with-dashes');
+      expect(collectionWithDashes).toBeDefined();
+      
+      const collectionWithUnderscores = result.collections.find((c: any) => c.slug === 'collection_with_underscores');
+      expect(collectionWithUnderscores).toBeDefined();
+      
+      const typeCollection = result.collections.find((c: any) => c.slug === 'type');
+      expect(typeCollection).toBeDefined();
+      
+      // Check collection references
+      expect(result.collectionRefs).toHaveProperty('collection-with-dashes');
+      expect(result.collectionRefs).toHaveProperty('collection_with_underscores');
+      expect(result.collectionRefs).toHaveProperty('type');
+    });
+  });
+
+  describe('Mixed Field Types and Relationships', () => {
+    it('should handle a mix of all field types and relationship types in one collection', () => {
+      const schema = {
+        kitchen: {
+          // Basic field types
+          textField: 'text',
+          textareaField: 'textarea',
+          richtextField: 'richtext',
+          numberField: 'number',
+          dateField: 'date',
+          emailField: 'email',
+          checkboxField: 'checkbox',
+          jsonField: 'json',
+          
+          // Select fields
+          statusSelect: 'Active | Inactive | Pending',
+          
+          // Relationship fields
+          singleRelation: 'sink',
+          multipleRelation: 'sink[]',
+          
+          // Self-referential relationship
+          parent: 'kitchen',
+          children: 'kitchen[]'
+        },
+        sink: {
+          name: 'text',
+          kitchenReference: '<-kitchen.singleRelation',
+          kitchenReferences: '<-kitchen.multipleRelation'
+        }
+      };
+      
+      const result = DB(schema);
+      
+      // Verify all collections exist
+      expect(result.collections).toHaveLength(2);
+      
+      // Find the kitchen collection
+      const kitchenCollection = result.collections.find((c: any) => c.slug === 'kitchen');
+      expect(kitchenCollection).toBeDefined();
+      
+      // Check that all field types are processed
+      expect(kitchenCollection?.fields.length).toBeGreaterThanOrEqual(12);
+      
+      // Check basic field types
+      const textField = kitchenCollection?.fields.find((f: any) => f.name === 'textField');
+      expect(textField?.type).toBe('text');
+      
+      const numberField = kitchenCollection?.fields.find((f: any) => f.name === 'numberField');
+      expect(numberField?.type).toBe('number');
+      
+      // Check select field
+      const statusSelect = kitchenCollection?.fields.find((f: any) => f.name === 'statusSelect') as any;
+      expect(statusSelect?.type).toBe('select');
+      if (statusSelect?.options) {
+        expect(statusSelect.options).toHaveLength(3);
+      }
+      
+      // Check relationship fields
+      const singleRelation = kitchenCollection?.fields.find((f: any) => f.name === 'singleRelation') as any;
+      expect(singleRelation?.type).toBe('relationship');
+      expect(singleRelation?.relationTo).toBe('sink');
+      expect(singleRelation?.hasMany).toBeUndefined();
+      
+      const multipleRelation = kitchenCollection?.fields.find((f: any) => f.name === 'multipleRelation') as any;
+      expect(multipleRelation?.type).toBe('relationship');
+      expect(multipleRelation?.relationTo).toBe('sink');
+      expect(multipleRelation?.hasMany).toBe(true);
+      
+      // Check self-referential relationships
+      const parent = kitchenCollection?.fields.find((f: any) => f.name === 'parent') as any;
+      expect(parent?.type).toBe('relationship');
+      expect(parent?.relationTo).toBe('kitchen');
+      expect(parent?.hasMany).toBeUndefined();
+      
+      const children = kitchenCollection?.fields.find((f: any) => f.name === 'children') as any;
+      expect(children?.type).toBe('relationship');
+      expect(children?.relationTo).toBe('kitchen');
+      expect(children?.hasMany).toBe(true);
+    });
+  });
+});

--- a/src/__tests__/comprehensive-fields.test.ts
+++ b/src/__tests__/comprehensive-fields.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from 'vitest';
+import { DB } from '../index';
+import { transformField, processFields } from '../utils/fieldTransformer';
+
+describe('Comprehensive Field Type Tests', () => {
+  describe('Basic Field Types', () => {
+    it('should handle all basic field types correctly', () => {
+      const schema = {
+        allFields: {
+          textField: 'text',
+          textareaField: 'textarea',
+          richtextField: 'richtext',
+          numberField: 'number',
+          dateField: 'date',
+          emailField: 'email',
+          checkboxField: 'checkbox',
+          jsonField: 'json'
+        }
+      };
+      
+      const result = DB(schema);
+      
+      // Verify the collection exists
+      expect(result.collections).toHaveLength(1);
+      const collection = result.collections[0];
+      expect(collection.slug).toBe('allFields');
+      
+      // Verify all fields are processed correctly
+      expect(collection.fields).toHaveLength(8);
+      
+      // Check each field type
+      const textField = collection.fields.find((f: any) => f.name === 'textField');
+      expect(textField?.type).toBe('text');
+      
+      const textareaField = collection.fields.find((f: any) => f.name === 'textareaField');
+      expect(textareaField?.type).toBe('textarea');
+      
+      const richtextField = collection.fields.find((f: any) => f.name === 'richtextField');
+      expect(richtextField?.type).toBe('richText');
+      
+      const numberField = collection.fields.find((f: any) => f.name === 'numberField');
+      expect(numberField?.type).toBe('number');
+      
+      const dateField = collection.fields.find((f: any) => f.name === 'dateField');
+      expect(dateField?.type).toBe('date');
+      
+      const emailField = collection.fields.find((f: any) => f.name === 'emailField');
+      expect(emailField?.type).toBe('email');
+      
+      const checkboxField = collection.fields.find((f: any) => f.name === 'checkboxField');
+      expect(checkboxField?.type).toBe('checkbox');
+      
+      const jsonField = collection.fields.find((f: any) => f.name === 'jsonField');
+      expect(jsonField?.type).toBe('json');
+    });
+  });
+
+  describe('Select Field Variations', () => {
+    it('should handle select fields with different separator styles', () => {
+      const schema = {
+        selectFields: {
+          withSpaces: 'Option A | Option B | Option C',
+          withoutSpaces: 'OptionA|OptionB|OptionC',
+          mixedCase: 'CamelCase | snake_case | kebab-case',
+          withNumbers: 'Option1 | Option2 | Option3',
+          withSpecialChars: 'Option-1 | Option_2 | Option.3'
+        }
+      };
+      
+      const result = DB(schema);
+      
+      // Verify the collection exists
+      expect(result.collections).toHaveLength(1);
+      const collection = result.collections[0];
+      
+      // Check each select field
+      const withSpaces = collection.fields.find((f: any) => f.name === 'withSpaces') as any;
+      expect(withSpaces?.type).toBe('select');
+      if (withSpaces?.options) {
+        expect(withSpaces.options).toHaveLength(3);
+        expect(withSpaces.options[0].label).toBe('Option A');
+        expect(withSpaces.options[0].value).toBe('option-a');
+      }
+      
+      const withoutSpaces = collection.fields.find((f: any) => f.name === 'withoutSpaces') as any;
+      expect(withoutSpaces?.type).toBe('select');
+      if (withoutSpaces?.options) {
+        expect(withoutSpaces.options).toHaveLength(3);
+      }
+      
+      const mixedCase = collection.fields.find((f: any) => f.name === 'mixedCase') as any;
+      expect(mixedCase?.type).toBe('select');
+      if (mixedCase?.options) {
+        expect(mixedCase.options).toHaveLength(3);
+        expect(mixedCase.options[0].value).toBe('camelcase');
+        expect(mixedCase.options[1].value).toBe('snake-case');
+        expect(mixedCase.options[2].value).toBe('kebab-case');
+      }
+      
+      const withNumbers = collection.fields.find((f: any) => f.name === 'withNumbers') as any;
+      expect(withNumbers?.type).toBe('select');
+      if (withNumbers?.options) {
+        expect(withNumbers.options).toHaveLength(3);
+      }
+      
+      const withSpecialChars = collection.fields.find((f: any) => f.name === 'withSpecialChars') as any;
+      expect(withSpecialChars?.type).toBe('select');
+      if (withSpecialChars?.options) {
+        expect(withSpecialChars.options).toHaveLength(3);
+      }
+    });
+  });
+
+  describe('Relationship Field Variations', () => {
+    it('should handle single and many relationship fields correctly', () => {
+      const schema = {
+        posts: {
+          title: 'text',
+          author: 'users',           // Single relationship
+          categories: 'categories[]', // Many relationship
+          tags: 'tags[]'             // Many relationship to tags
+        },
+        users: {
+          name: 'text'
+        },
+        categories: {
+          name: 'text'
+        },
+        tags: {
+          name: 'text'
+        }
+      };
+      
+      const result = DB(schema);
+      
+      // Verify all collections exist
+      expect(result.collections).toHaveLength(4);
+      
+      // Find the posts collection
+      const postsCollection = result.collections.find((c: any) => c.slug === 'posts');
+      expect(postsCollection).toBeDefined();
+      
+      // Check single relationship field
+      const authorField = postsCollection?.fields.find((f: any) => f.name === 'author') as any;
+      expect(authorField?.type).toBe('relationship');
+      expect(authorField?.relationTo).toBe('users');
+      expect(authorField?.hasMany).toBeUndefined();
+      
+      // Check many relationship field
+      const categoriesField = postsCollection?.fields.find((f: any) => f.name === 'categories') as any;
+      expect(categoriesField?.type).toBe('relationship');
+      expect(categoriesField?.relationTo).toBe('categories');
+      expect(categoriesField?.hasMany).toBe(true);
+      
+      // Check tags relationship field
+      const tagsField = postsCollection?.fields.find((f: any) => f.name === 'tags') as any;
+      expect(tagsField?.type).toBe('relationship');
+      expect(tagsField?.relationTo).toBe('tags');
+      expect(tagsField?.hasMany).toBe(true);
+    });
+  });
+
+  describe('Join Field Variations', () => {
+    it('should handle join fields with and without specific source fields', () => {
+      const schema = {
+        posts: {
+          title: 'text',
+          author: 'users',
+          categories: 'categories[]'
+        },
+        users: {
+          name: 'text',
+          authoredPosts: '<-posts.author',  // Join with specific source field
+          allPosts: '<-posts'               // Join without specific source field
+        },
+        categories: {
+          name: 'text',
+          categorizedPosts: '<-posts.categories' // Join with specific source field
+        }
+      };
+      
+      const result = DB(schema);
+      
+      // Verify all collections exist
+      expect(result.collections).toHaveLength(3);
+      
+      // Find the collections
+      const postsCollection = result.collections.find((c: any) => c.slug === 'posts');
+      const usersCollection = result.collections.find((c: any) => c.slug === 'users');
+      const categoriesCollection = result.collections.find((c: any) => c.slug === 'categories');
+      
+      expect(postsCollection).toBeDefined();
+      expect(usersCollection).toBeDefined();
+      expect(categoriesCollection).toBeDefined();
+      
+      // Check that join fields are not directly in the collections
+      const authoredPostsField = usersCollection?.fields.find((f: any) => f.name === 'authoredPosts');
+      expect(authoredPostsField).toBeUndefined();
+      
+      const allPostsField = usersCollection?.fields.find((f: any) => f.name === 'allPosts');
+      expect(allPostsField).toBeUndefined();
+      
+      const categorizedPostsField = categoriesCollection?.fields.find((f: any) => f.name === 'categorizedPosts');
+      expect(categorizedPostsField).toBeUndefined();
+      
+      // Check that the source fields have been properly configured
+      const authorField = postsCollection?.fields.find((f: any) => f.name === 'author') as any;
+      expect(authorField).toBeDefined();
+      expect(authorField?.admin?.enableRichText).toBe(true);
+      
+      // Check that the fields array exists on the source fields
+      expect(authorField?.fields).toBeDefined();
+      
+      // Check that the join fields are properly set up in the source fields
+      const authoredPostsJoinField = authorField?.fields.find((f: any) => f.name === 'authoredPosts') as any;
+      expect(authoredPostsJoinField).toBeDefined();
+      expect(authoredPostsJoinField?.type).toBe('relationship');
+      expect(authoredPostsJoinField?.relationTo).toBe('posts');
+      expect(authoredPostsJoinField?.hasMany).toBe(true);
+      
+      const categoriesField = postsCollection?.fields.find((f: any) => f.name === 'categories') as any;
+      expect(categoriesField).toBeDefined();
+      expect(categoriesField?.admin?.enableRichText).toBe(true);
+      
+      // Check that the fields array exists on the source fields
+      expect(categoriesField?.fields).toBeDefined();
+      
+      // Check that the join fields are properly set up in the source fields
+      const categorizedPostsJoinField = categoriesField?.fields.find((f: any) => f.name === 'categorizedPosts') as any;
+      expect(categorizedPostsJoinField).toBeDefined();
+      expect(categorizedPostsJoinField?.type).toBe('relationship');
+      expect(categorizedPostsJoinField?.relationTo).toBe('posts');
+      expect(categorizedPostsJoinField?.hasMany).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
This PR updates the test suite to ensure all possible permutations of collections/fields exist and are passing.

Added comprehensive tests for:
- All basic field types (text, textarea, richtext, number, date, email, checkbox, json)
- Select field variations with different separator styles
- Relationship field variations (single and many)
- Join field variations with and without specific source fields
- Complex nested relationships
- Circular references between collections
- Edge cases with field and collection names
- Mixed field types and relationships in one collection

Link to Devin run: https://app.devin.ai/sessions/8a06453b4f9c46e392a16c740e28a366
Requested by: user